### PR TITLE
invert marked color

### DIFF
--- a/skins/dracula.ini
+++ b/skins/dracula.ini
@@ -27,7 +27,7 @@
 [core]
     _default_ = white;default
     selected = white;red
-    marked = brightgreen;black
+    marked = black;brightgreen
     markselect = brightgreen;blue
     gauge = black;white
     input = white;black

--- a/skins/dracula256.ini
+++ b/skins/dracula256.ini
@@ -28,7 +28,7 @@
 [core]
     _default_ = rgb555;default
     selected = color0;rgb524
-    marked = rgb253;color0
+    marked = color0;rgb253
     markselect = rgb253;rgb524
     gauge = color0;rgb555
     input = rgb555;color0


### PR DESCRIPTION

I find it is super difficult to differentiate between selected file with media files, they both got the same text color. Maybe a good idea to invert the marked color.

Before:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/62332195/233542722-6ab8cb2d-c2dc-45d9-944b-112e10d8c4fb.png">


After:
![SCR-20230421-g18](https://user-images.githubusercontent.com/62332195/233542394-ca63cc22-3e8b-4705-9cb3-e9e75ce04c8e.jpeg)
